### PR TITLE
Add base monitor class and fix config

### DIFF
--- a/blockchain_common/base_monitor.py
+++ b/blockchain_common/base_monitor.py
@@ -1,0 +1,11 @@
+from settings import CONFIG
+
+
+class BaseMonitor:
+    network_type: str
+    event_type: str
+    queue: str
+
+    def __init__(self, network):
+        self.network_type = network
+        self.queue = CONFIG['networks'][self.network_type]['queue']

--- a/eventscanner/monitors/payments/eth_payment_monitor.py
+++ b/eventscanner/monitors/payments/eth_payment_monitor.py
@@ -1,18 +1,14 @@
+from blockchain_common.base_monitor import BaseMonitor
 from eventscanner.queue.pika_handler import send_to_backend
 from mywish_models.models import UserSiteBalance, session
 from scanner.events.block_event import BlockEvent
-from settings import CONFIG
 
 
-class EthPaymentMonitor:
-
-    network_types = ['ETHEREUM_MAINNET']
+class EthPaymentMonitor(BaseMonitor):
     event_type = 'payment'
-    queue = CONFIG['networks'][network_types[0]]['queue']
 
-    @classmethod
-    def on_new_block_event(cls, block_event: BlockEvent):
-        if block_event.network.type not in cls.network_types:
+    def on_new_block_event(self, block_event: BlockEvent):
+        if block_event.network.type != self.network_type:
             return
 
         addresses = block_event.transactions_by_address.keys()
@@ -42,4 +38,4 @@ class EthPaymentMonitor:
                     'status': 'COMMITTED'
                 }
 
-                send_to_backend(cls.event_type, cls.queue, message)
+                send_to_backend(self.event_type, self.queue, message)

--- a/eventscanner/queue/subscribers.py
+++ b/eventscanner/queue/subscribers.py
@@ -4,10 +4,10 @@ from settings import CONFIG
 from .. import monitors
 
 for name, monitor_config in CONFIG["monitors"].items():
-    monitor = getattr(monitors, name, None)
-    if monitor:
-        method = monitor_config.get("method", None)
+    monitor_class = getattr(monitors, name, None)
+    if monitor_class:
         networks = monitor_config["networks"]
 
         for network in networks:
+            monitor = monitor_class(network)
             pub.subscribe(monitor.on_new_block_event, network)

--- a/eventscanner/queue/subscribers.py
+++ b/eventscanner/queue/subscribers.py
@@ -3,6 +3,7 @@ from pubsub import pub
 from settings import CONFIG
 from .. import monitors
 
+subscribe_list = []
 for name, monitor_config in CONFIG["monitors"].items():
     monitor_class = getattr(monitors, name, None)
     if monitor_class:
@@ -10,4 +11,9 @@ for name, monitor_config in CONFIG["monitors"].items():
 
         for network in networks:
             monitor = monitor_class(network)
-            pub.subscribe(monitor.on_new_block_event, network)
+            subscribe_list.append((monitor.on_new_block_event, network))
+
+# pubsub lib do not remember variables, created inside loop.
+# So, we create list of variables in one loop, and then push it to pubsub
+for elem in subscribe_list:
+    pub.subscribe(*elem)

--- a/networks/eth/network.py
+++ b/networks/eth/network.py
@@ -3,6 +3,7 @@ import time
 import requests
 from hexbytes import HexBytes
 from web3 import Web3
+from web3.middleware import geth_poa_middleware
 
 from blockchain_common.eth_tokens import erc20_abi
 from blockchain_common.wrapper_block import WrapperBlock
@@ -17,8 +18,13 @@ class EthNetwork(WrapperNetwork):
 
     def __init__(self, type):
         super().__init__(type)
-        url = CONFIG['networks'][type]['url']
+        config = CONFIG['networks'][type]
+        url = config['url']
         self.web3 = Web3(Web3.HTTPProvider(url))
+
+        # Disable ethereum special checks, if network used for non-eth chain
+        if config.get('remove_middleware'):
+            self.web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
         etherscan_api_key = CONFIG['networks'][type].get('etherscan_api_key')
         is_testnet = CONFIG['networks'][type].get('is_testnet')

--- a/networks/eth/scanner.py
+++ b/networks/eth/scanner.py
@@ -22,8 +22,6 @@ class EthScanner(ScannerPolling):
             self._check_tx_from(transaction, address_transactions)
             self._check_tx_to(transaction, address_transactions)
 
-        print('{}: transactions'.format(self.network.type), address_transactions, flush=True)
-
         events = self._find_event(block)
         block_event = BlockEvent(self.network, block=block, events=events, transactions_by_address=address_transactions)
         pub.sendMessage(self.network.type, block_event=block_event)

--- a/networks/eth/scanner.py
+++ b/networks/eth/scanner.py
@@ -1,15 +1,11 @@
 import collections
-from web3 import Web3
 from web3.exceptions import LogTopicError
 
-from settings import CONFIG
 from eventscanner.queue.subscribers import pub
 from scanner.events.block_event import BlockEvent
 from blockchain_common.wrapper_block import WrapperBlock
 from scanner.services.scanner_polling import ScannerPolling
 from blockchain_common.eth_tokens import abi_airdrop, token_abi
-
-web3 = Web3(Web3.HTTPProvider(CONFIG["networks"]["ETHEREUM_MAINNET"]["url"]))
 
 
 class EthScanner(ScannerPolling):
@@ -71,7 +67,7 @@ class EthScanner(ScannerPolling):
         }
         for event, abi in events.items():
             try:
-                contract = web3.eth.contract(abi=abi)
+                contract = self.network.web3.eth.contract(abi=abi)
                 event_filter = contract.events.__getitem__(event).createFilter(fromBlock=block.number, toBlock=block.number)
                 entries = event_filter.get_all_entries()
                 if entries:

--- a/networks/eth/scanner.py
+++ b/networks/eth/scanner.py
@@ -29,7 +29,7 @@ class EthScanner(ScannerPolling):
         print('{}: transactions'.format(self.network.type), address_transactions, flush=True)
 
         events = self._find_event(block)
-        block_event = BlockEvent(self.network, block=block, events=events, transactions=address_transactions)
+        block_event = BlockEvent(self.network, block=block, events=events, transactions_by_address=address_transactions)
         pub.sendMessage(self.network.type, block_event=block_event)
 
     def _check_tx_from(self, tx, addresses):

--- a/settings/config.example.yaml
+++ b/settings/config.example.yaml
@@ -23,12 +23,12 @@ networks:
 # One monitor can listen to multiple networks
 monitors:
   MONITOR_NAME:
-    method: METHOD_NAME
+    # Different monitor instances for each net will be created
     networks:
-      - NETWORK_NAME
+      - NETWORK_NAME_FIRST
+      - NETWORK_NAME_SECOND
   # Example monitor to work with ethereum
   EthPaymentMonitor:
-    method: new
     networks:
       - ETHEREUM_MAINNET
 

--- a/settings/config.example.yaml
+++ b/settings/config.example.yaml
@@ -5,6 +5,9 @@ networks:
     polling_interval: 10
     commitment_chain_length: 5
     queue: 'name'
+    # This parameter required for all non-eth chains, witch use EthScanner as base.
+    # False by default. For example, used in BSC and Matic.
+    remove_middleware: True
     scanner_makers:
       - FIRST_SCANNER_MAKER_NAME
       - SECOND_SCANNER_MAKER_NAME
@@ -17,7 +20,10 @@ networks:
       - EthMaker
   # After this will be placed unique keys for specific networks
   ETHEREUM:
-    etherscan_api_key: 'key_string' # etherscan key to obtain parsed logs
+    # etherscan key to obtain parsed logs
+    etherscan_api_key: 'key_string'
+  BINANCE:
+    remove_middleware: True
 
 # All monitors, witch should listen for specific network events
 # One monitor can listen to multiple networks


### PR DESCRIPTION
* Update monitors with base class, which create monitor instance for every required network separately.
* Add `geth_poa_middleware` parameter to config to run scanners with web3 not only on Ethereum chain (but on binance-sc too)
* Remove redundant web3 from eth_scanner (cause it allready was in self.network)
* Fix block_event naming
